### PR TITLE
Bump log4j to 2.16.0

### DIFF
--- a/aws-nimblestudio-streamingimage/pom.xml
+++ b/aws-nimblestudio-streamingimage/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.13.3</version>
+            <version>2.16.0</version>
         </dependency>
     </dependencies>
 

--- a/aws-nimblestudio-studiocomponent/pom.xml
+++ b/aws-nimblestudio-studiocomponent/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.13.3</version>
+            <version>2.16.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Changes:
- bumps log4j version to 2.16.0 based on the recent announcement: https://lists.apache.org/thread/83y7dx5xvn3h5290q1twn16tltolv88f

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
